### PR TITLE
CI/Docker: return rustfmt back to container setup

### DIFF
--- a/.build/Dockerfile
+++ b/.build/Dockerfile
@@ -3,8 +3,8 @@ FROM rust:1.40 as build
 ENV RUSTUP_TOOLCHAIN="stable-x86_64-unknown-linux-gnu"
 ENV RUST_BACKTRACE=full
 
-RUN rustup install stable
-# rustup component add rustfmt && \
+RUN rustup install stable && \
+rustup component add rustfmt
 # rustup component add clippy
 
 WORKDIR /opt/app


### PR DESCRIPTION
CI/Docker: return back previously disabled rustfmt because needed for codegen.
[Caused there.](https://github.com/dfinance/dvm/pull/85/checks?check_run_id=622038462)