### PR TITLE
CI: fix terminal signals

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,9 +75,8 @@ jobs:
         curl -H "Authorization: Bearer ${SENTRY_API_TOKEN}" https://$SENTRY_HOST_URI/api/0/projects/$SENTRY_COMPANY_PROJECT/events/ 2>&1 | grep "$SENTRY_CROSS_RANDOM_TAG" 1>/dev/null
 
     # terminal signals
+    - run: cargo build --all
     - name: SIGs handling
-      # TODO: fix test, make compat with nix
-      if: matrix.os != 'ubuntu-latest'
       run: |
         tests/test-shutdown.sh dvm
         tests/test-shutdown.sh compiler

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,8 +75,9 @@ jobs:
         curl -H "Authorization: Bearer ${SENTRY_API_TOKEN}" https://$SENTRY_HOST_URI/api/0/projects/$SENTRY_COMPANY_PROJECT/events/ 2>&1 | grep "$SENTRY_CROSS_RANDOM_TAG" 1>/dev/null
 
     # terminal signals
-    - name: SIGs handling (DVM)
-      run: tests/test-shutdown.sh dvm
-
-    - name: SIGs handling (compiler)
-      run: tests/test-shutdown.sh compiler
+    - name: SIGs handling
+      # TODO: fix test, make compat with nix
+      if: matrix.os != 'ubuntu-latest'
+      run: |
+        tests/test-shutdown.sh dvm
+        tests/test-shutdown.sh compiler

--- a/tests/test-shutdown.sh
+++ b/tests/test-shutdown.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Usage:
 # PWD should be root of workspace (project)
@@ -22,7 +22,7 @@ EXPECTED_KILL_EXIT_CODE=0
 EXPECTED_STDERR_LOG_SIZE=0
 
 # build
-cargo build --bin $1
+# cargo build --bin $1
 
 # run with verbosity and log redirection
 ./target/debug/$1 -v > $STDOUT_LOG_PATH 2>$STDERR_LOG_PATH &
@@ -41,7 +41,7 @@ echo "$1 exit-code: $EXECUTABLE_EXIT_CODE"
 echo "kill exit-code: $EXECUTABLE_KILL_EXIT_CODE"
 
 # check kill exit code:
-if [ $EXECUTABLE_KILL_EXIT_CODE == $EXPECTED_KILL_EXIT_CODE ]; then
+if [ "$EXECUTABLE_KILL_EXIT_CODE" == "$EXPECTED_KILL_EXIT_CODE" ]; then
   echo "SIGTERM catched: OK"
 else
   echo "SIGTERM not catched: ERR: $EXECUTABLE_KILL_EXIT_CODE != $EXPECTED_KILL_EXIT_CODE"

--- a/tests/test-shutdown.sh
+++ b/tests/test-shutdown.sh
@@ -41,7 +41,7 @@ echo "$1 exit-code: $EXECUTABLE_EXIT_CODE"
 echo "kill exit-code: $EXECUTABLE_KILL_EXIT_CODE"
 
 # check kill exit code:
-if [ "$EXECUTABLE_KILL_EXIT_CODE" == "$EXPECTED_KILL_EXIT_CODE" ]; then
+if (( $EXECUTABLE_KILL_EXIT_CODE == $EXPECTED_KILL_EXIT_CODE )); then
   echo "SIGTERM catched: OK"
 else
   echo "SIGTERM not catched: ERR: $EXECUTABLE_KILL_EXIT_CODE != $EXPECTED_KILL_EXIT_CODE"
@@ -49,7 +49,7 @@ else
 fi
 
 # check the exit code:
-if [ $EXECUTABLE_EXIT_CODE == $EXPECTED_EXIT_CODE ]; then
+if (( $EXECUTABLE_EXIT_CODE == $EXPECTED_EXIT_CODE )); then
   echo "exit-code: OK"
 else
   echo "exit-code: ERR: $EXECUTABLE_EXIT_CODE != $EXPECTED_EXIT_CODE"

--- a/tests/test-shutdown.sh
+++ b/tests/test-shutdown.sh
@@ -35,7 +35,7 @@ echo "killing-timer setted up for $EXECUTABLE_PID"
 
 wait "$EXECUTABLE_PID"
 EXECUTABLE_EXIT_CODE=$?
-EXECUTABLE_KILL_EXIT_CODE=`cat $KILL_EXIT_CODE_PATH`
+EXECUTABLE_KILL_EXIT_CODE=$(cat $KILL_EXIT_CODE_PATH)
 
 echo "$1 exit-code: $EXECUTABLE_EXIT_CODE"
 echo "kill exit-code: $EXECUTABLE_KILL_EXIT_CODE"
@@ -57,7 +57,7 @@ else
 fi
 
 # check size of stderr:
-STDERR_LOG=`cat $STDERR_LOG_PATH`
+STDERR_LOG=$(cat $STDERR_LOG_PATH)
 STDERR_LOG_SIZE=${#STDERR_LOG}
 if [ $STDERR_LOG_SIZE == $EXPECTED_STDERR_LOG_SIZE ]; then
   echo "stderr size: OK"
@@ -67,7 +67,7 @@ else
 fi
 
 # check size of stdout:
-STDOUT_LOG=`cat $STDOUT_LOG_PATH`
+STDOUT_LOG=$(cat $STDOUT_LOG_PATH)
 STDOUT_LOG_SIZE=${#STDOUT_LOG}
 if [ $STDOUT_LOG_SIZE -gt 0 ]; then
   echo "stdout size: OK"


### PR DESCRIPTION
temporary disable test for *nix because the test used incompatible shell commands.