### PR TITLE
CI: fix terminal signals

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,9 +74,9 @@ jobs:
         cargo test -p dvm-cli --manifest-path cli/Cargo.toml --lib --features integrity-tests panic_sentry_integrity
         curl -H "Authorization: Bearer ${SENTRY_API_TOKEN}" https://$SENTRY_HOST_URI/api/0/projects/$SENTRY_COMPANY_PROJECT/events/ 2>&1 | grep "$SENTRY_CROSS_RANDOM_TAG" 1>/dev/null
 
-    # terminal signals
-    - name: SIGs handling (DVM)
-      run: tests/test-shutdown.sh dvm
-
-    - name: SIGs handling (compiler)
-      run: tests/test-shutdown.sh compiler
+    - name: SIGs handling
+      # TODO: fix test, make compat with nix
+      if: matrix.os != 'ubuntu-latest'
+      run: |
+        tests/test-shutdown.sh dvm
+        tests/test-shutdown.sh compiler

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -74,9 +74,9 @@ jobs:
         cargo test -p dvm-cli --manifest-path cli/Cargo.toml --lib --features integrity-tests panic_sentry_integrity
         curl -H "Authorization: Bearer ${SENTRY_API_TOKEN}" https://$SENTRY_HOST_URI/api/0/projects/$SENTRY_COMPANY_PROJECT/events/ 2>&1 | grep "$SENTRY_CROSS_RANDOM_TAG" 1>/dev/null
 
+    # terminal signals
+    - run: cargo build --all
     - name: SIGs handling
-      # TODO: fix test, make compat with nix
-      if: matrix.os != 'ubuntu-latest'
       run: |
         tests/test-shutdown.sh dvm
         tests/test-shutdown.sh compiler

--- a/tests/test-shutdown.sh
+++ b/tests/test-shutdown.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Usage:
 # PWD should be root of workspace (project)
@@ -22,7 +22,7 @@ EXPECTED_KILL_EXIT_CODE=0
 EXPECTED_STDERR_LOG_SIZE=0
 
 # build
-cargo build --bin $1
+# cargo build --bin $1
 
 # run with verbosity and log redirection
 ./target/debug/$1 -v > $STDOUT_LOG_PATH 2>$STDERR_LOG_PATH &
@@ -41,7 +41,7 @@ echo "$1 exit-code: $EXECUTABLE_EXIT_CODE"
 echo "kill exit-code: $EXECUTABLE_KILL_EXIT_CODE"
 
 # check kill exit code:
-if [ $EXECUTABLE_KILL_EXIT_CODE == $EXPECTED_KILL_EXIT_CODE ]; then
+if [ "$EXECUTABLE_KILL_EXIT_CODE" == "$EXPECTED_KILL_EXIT_CODE" ]; then
   echo "SIGTERM catched: OK"
 else
   echo "SIGTERM not catched: ERR: $EXECUTABLE_KILL_EXIT_CODE != $EXPECTED_KILL_EXIT_CODE"


### PR DESCRIPTION
temporary disable test for *nix because the test used incompatible shell commands.