### PR TITLE
fix names of executables in the output of help and version (DFI-307)

### DIFF
--- a/cli/src/bin/status-table.rs
+++ b/cli/src/bin/status-table.rs
@@ -7,7 +7,9 @@ use anyhow::Result;
 use std::fs::OpenOptions;
 use std::io::Write;
 
+/// Status table generator.
 #[derive(StructOpt)]
+#[structopt(name = "status-table")]
 struct Opts {
     /// Optional path to the output file.
     /// If not passed, result will be printed to stdout.

--- a/cli/src/bin/stdlib-builder.rs
+++ b/cli/src/bin/stdlib-builder.rs
@@ -7,6 +7,7 @@ use anyhow::Error;
 use std::collections::HashMap;
 
 #[derive(StructOpt)]
+#[structopt(name = "stdlib-builder")]
 struct Opts {
     /// Path to the directory with the standard library.
     #[structopt()]


### PR DESCRIPTION
continue of #121