### PR TITLE
Signer, move_to and no more Tx::sender()

### DIFF
--- a/lang/stdlib/account.move
+++ b/lang/stdlib/account.move
@@ -7,11 +7,12 @@ module Account {
 
     use 0x0::Transaction;
     use 0x0::Dfinance;
+    use 0x0::Signer;
     use 0x0::Event;
 
     /// holds account data, currently, only events
     resource struct T {
-        sent_events: Event::EventHandle<SentPaymentEvent>,
+        sent_events:     Event::EventHandle<SentPaymentEvent>,
         received_events: Event::EventHandle<ReceivedPaymentEvent>,
     }
 
@@ -36,11 +37,11 @@ module Account {
     }
 
     /// Init wallet for measurable currency, hence accept <Token> currency
-    public fun accept<Token>() {
-        move_to_sender<Balance<Token>>(Balance { coin: Dfinance::zero<Token>() })
+    public fun accept<Token>(account: &signer) {
+        move_to<Balance<Token>>(account, Balance { coin: Dfinance::zero<Token>() })
     }
 
-    public fun can_accept<Token>(payee: address): bool {
+    public fun has_balance<Token>(payee: address): bool {
         ::exists<Balance<Token>>(payee)
     }
 
@@ -48,56 +49,80 @@ module Account {
         ::exists<T>(payee)
     }
 
-    public fun balance<Token>(): u128 acquires Balance {
-        balance_for<Token>(Transaction::sender())
+    public fun balance<Token>(account: &signer): u128 acquires Balance {
+        balance_for<Token>(Signer::address_of(account))
     }
 
     public fun balance_for<Token>(addr: address): u128 acquires Balance {
         Dfinance::value(&borrow_global<Balance<Token>>(addr).coin)
     }
 
-    public fun deposit<Token>(payee: address, to_deposit: Dfinance::T<Token>)
-    acquires T, Balance {
-        deposit_with_metadata(payee, to_deposit, x"")
+    public fun deposit_to_sender<Token>(
+        account: &signer,
+        to_deposit: Dfinance::T<Token>
+    ) acquires T, Balance {
+        deposit<Token>(
+            account,
+            Signer::address_of(account),
+            to_deposit
+        )
     }
 
-    public fun deposit_to_sender<Token>(to_deposit: Dfinance::T<Token>)
-    acquires T, Balance {
-        deposit(Transaction::sender(), to_deposit)
+    public fun deposit<Token>(
+        account: &signer,
+        payee: address,
+        to_deposit: Dfinance::T<Token>
+    ) acquires T, Balance {
+        deposit_with_metadata<Token>(
+            account,
+            payee,
+            to_deposit,
+            b""
+        )
     }
 
     public fun deposit_with_metadata<Token>(
+        account: &signer,
         payee: address,
         to_deposit: Dfinance::T<Token>,
         metadata: vector<u8>
     ) acquires T, Balance {
-        deposit_with_sender_and_metadata(
+        deposit_with_sender_and_metadata<Token>(
+            account,
             payee,
-            Transaction::sender(),
             to_deposit,
             metadata
         )
     }
 
-    public fun pay_from_sender<Token>(payee: address, amount: u128)
-    acquires T, Balance {
+    public fun pay_from_sender<Token>(
+        account: &signer,
+        payee: address,
+        amount: u128
+    ) acquires T, Balance {
         pay_from_sender_with_metadata<Token>(
-            payee, amount, x""
+            account, payee, amount, b""
         )
     }
 
-    public fun pay_from_sender_with_metadata<Token>(payee: address, amount: u128, metadata: vector<u8>)
+    public fun pay_from_sender_with_metadata<Token>(
+        account: &signer,
+        payee: address,
+        amount: u128,
+        metadata: vector<u8>
+    )
     acquires T, Balance {
         deposit_with_metadata<Token>(
+            account,
             payee,
-            withdraw_from_sender(amount),
+            withdraw_from_sender<Token>(account, amount),
             metadata
         )
     }
 
     fun deposit_with_sender_and_metadata<Token>(
+        sender: &signer,
         payee: address,
-        sender: address,
         to_deposit: Dfinance::T<Token>,
         metadata: vector<u8>
     ) acquires T, Balance {
@@ -105,7 +130,7 @@ module Account {
         Transaction::assert(amount > 0, 7);
 
         let denom = Dfinance::denom<Token>();
-        let sender_acc = borrow_global_mut<T>(sender);
+        let sender_acc = borrow_global_mut<T>(Signer::address_of(sender));
 
         // add event as sent into account
         Event::emit_event<SentPaymentEvent>(
@@ -119,12 +144,12 @@ module Account {
         );
 
         // there's no way to improve this place as payee is not sender :(
-        if (!can_accept<Token>(payee)) {
-            save_balance<Token>(Balance { coin: Dfinance::zero<Token>() }, payee);
+        if (!has_balance<Token>(payee)) {
+            create_balance<Token>(payee);
         };
 
         if (!exists(payee)) {
-            new_account(payee);
+            create_account(payee);
         };
 
         let payee_acc     = borrow_global_mut<T>(payee);
@@ -139,15 +164,14 @@ module Account {
                 amount,
                 denom,
                 metadata,
-                payer: sender
+                payer: Signer::address_of(sender)
             }
         )
     }
 
-    public fun withdraw_from_sender<Token>(amount: u128): Dfinance::T<Token>
+    public fun withdraw_from_sender<Token>(account: &signer, amount: u128): Dfinance::T<Token>
     acquires Balance {
-        let sender  = Transaction::sender();
-        let balance = borrow_global_mut<Balance<Token>>(sender);
+        let balance = borrow_global_mut<Balance<Token>>(Signer::address_of(account));
 
         withdraw_from_balance<Token>(balance, amount)
     }
@@ -156,17 +180,30 @@ module Account {
         Dfinance::withdraw(&mut balance.coin, amount)
     }
 
-    fun new_account(addr: address) {
-        let evt = Event::new_event_generator(addr);
-        let acc = T {
-            sent_events: Event::new_event_handle_from_generator(&mut evt),
-            received_events: Event::new_event_handle_from_generator(&mut evt),
-         };
+    fun create_balance<Token>(addr: address) {
+        let sig = create_signer(addr);
 
-        save_account(acc, evt, addr);
+        move_to<Balance<Token>>(&sig, Balance {
+            coin: Dfinance::zero<Token>()
+        });
+
+        destroy_signer(sig);
     }
 
-    native fun save_balance<Token>(balance: Balance<Token>, addr: address);
-    native fun save_account(account: T, event_generator: Event::EventHandleGenerator, addr: address);
+    fun create_account(addr: address) {
+        let sig = create_signer(addr);
+
+        Event::publish_generator(&sig);
+
+        move_to<T>(&sig, T {
+            sent_events: Event::new_event_handle(&sig),
+            received_events: Event::new_event_handle(&sig),
+        });
+
+        destroy_signer(sig);
+    }
+
+    native fun create_signer(addr: address): signer;
+    native fun destroy_signer(sig: signer);
 }
 }

--- a/lang/stdlib/dfinance.move
+++ b/lang/stdlib/dfinance.move
@@ -6,6 +6,7 @@ address 0x0 {
 module Dfinance {
 
     use 0x0::Transaction;
+    use 0x0::Signer;
 
     resource struct T<Coin> {
         value: u128
@@ -54,9 +55,9 @@ module Dfinance {
     /// Work in progress. Make it public when register_token_info becomes native.
     /// Made private on purpose not to make a hole in chain security, though :resource
     /// constraint kinda-does the job and won't allow users to mint new 'real' coins
-    public fun tokenize<Token: resource>(total_supply: u128, decimals: u8, denom: vector<u8>): T<Token> {
+    public fun tokenize<Token: resource>(account: &signer, total_supply: u128, decimals: u8, denom: vector<u8>): T<Token> {
 
-        let owner = Transaction::sender();
+        let owner = Signer::address_of(account);
 
         // check if this token has never been registered
         Transaction::assert(!::exists<Info<Token>>(0x0), 1);
@@ -105,10 +106,10 @@ module Dfinance {
     }
 
     /// only 0x0 address and add denom descriptions, 0x0 holds information resource
-    public fun register_coin<Coin>(denom: vector<u8>, decimals: u8) {
-        assert_can_register_coin();
+    public fun register_coin<Coin>(account: &signer, denom: vector<u8>, decimals: u8) {
+        assert_can_register_coin(account);
 
-        move_to_sender<Info<Coin>>(Info {
+        move_to<Info<Coin>>(account, Info {
             denom,
             decimals,
 
@@ -119,8 +120,8 @@ module Dfinance {
     }
 
     /// check whether sender is 0x0, helper method
-    fun assert_can_register_coin() {
-        Transaction::assert(Transaction::sender() == 0x0, 1);
+    fun assert_can_register_coin(account: &signer) {
+        Transaction::assert(Signer::address_of(account) == 0x0, 1);
     }
 }
 }

--- a/lang/stdlib/event.move
+++ b/lang/stdlib/event.move
@@ -1,14 +1,9 @@
 address 0x0 {
 
 module Event {
-
     use 0x0::LCS;
+    use 0x0::Signer;
     use 0x0::Vector;
-    use 0x0::Transaction;
-
-    // An operations capability restricting who can create an
-    // EventHandleGenerator.
-    resource struct EventHandleGeneratorCreationCapability {}
 
     // A resource representing the counter used to generate uniqueness under each account. There won't be destructor for
     // this resource to guarantee the uniqueness of the generated handle.
@@ -28,15 +23,8 @@ module Event {
         guid: vector<u8>,
     }
 
-    public fun grant_event_handle_creation_operation(): EventHandleGeneratorCreationCapability {
-        Transaction::assert(Transaction::sender() == 0x0, 0);
-        EventHandleGeneratorCreationCapability{}
-    }
-
-    public fun new_event_generator(
-        addr: address
-    ): EventHandleGenerator {
-        EventHandleGenerator{ counter: 0, addr }
+    public fun publish_generator(account: &signer) {
+        move_to(account, EventHandleGenerator{ counter: 0, addr: Signer::address_of(account) })
     }
 
     // Derive a fresh unique id by using sender's EventHandleGenerator. The generated vector<u8> is indeed unique because it
@@ -55,17 +43,13 @@ module Event {
         count_bytes
     }
 
-    // Use EventHandleGenerator to generate a unique event handle that one can emit an event to.
-    public fun new_event_handle_from_generator<T: copyable>(event_generator: &mut EventHandleGenerator): EventHandle<T> {
-        EventHandle<T> {counter: 0, guid: fresh_guid(event_generator)}
-    }
-
-
-    // Use EventHandleGenerator to generate a unique event handle that one can emit an event to.
-    public fun new_event_handle<T: copyable>(): EventHandle<T>
+    // Use EventHandleGenerator to generate a unique event handle for `sig`
+    public fun new_event_handle<T: copyable>(account: &signer): EventHandle<T>
     acquires EventHandleGenerator {
-        let event_generator = borrow_global_mut<EventHandleGenerator>(Transaction::sender());
-        new_event_handle_from_generator(event_generator)
+        EventHandle<T> {
+            counter: 0,
+            guid: fresh_guid(borrow_global_mut<EventHandleGenerator>(Signer::address_of(account)))
+        }
     }
 
     // Emit an event with payload `msg` by using handle's key and counter. Will change the payload from vector<u8> to a

--- a/lang/stdlib/offer.move
+++ b/lang/stdlib/offer.move
@@ -1,40 +1,38 @@
 address 0x0 {
-
 // TODO: add optional timeout for reclaiming by original publisher once we have implemented time
 module Offer {
+  use 0x0::Signer;
+  use 0x0::Transaction;
+  // A wrapper around value `offered` that can be claimed by the address stored in `for`.
+  resource struct T<Offered> { offered: Offered, for: address }
 
-    use 0x0::Transaction;
+  // Publish a value of type `Offered` under the sender's account. The value can be claimed by
+  // either the `for` address or the transaction sender.
+  public fun create<Offered>(account: &signer, offered: Offered, for: address) {
+    move_to(account, T<Offered> { offered, for });
+  }
 
-    // A wrapper around value `offered` that can be claimed by the address stored in `for`.
-    resource struct T<Offered> { offered: Offered, for: address }
+  // Claim the value of type `Offered` published at `offer_address`.
+  // Only succeeds if the sender is the intended recipient stored in `for` or the original
+  // publisher `offer_address`.
+  // Also fails if no such value exists.
+  public fun redeem<Offered>(account: &signer, offer_address: address): Offered acquires T {
+    let T<Offered> { offered, for } = move_from<T<Offered>>(offer_address);
+    let sender = Signer::address_of(account);
+    // fail with INSUFFICIENT_PRIVILEGES
+    Transaction::assert(sender == for || sender == offer_address, 11);
+    offered
+  }
 
-    // Publish a value of type `Offered` under the sender's account. The value can be claimed by
-    // either the `for` address or the transaction sender.
-    public fun create<Offered>(offered: Offered, for: address) {
-        move_to_sender<T<Offered>>(T<Offered> { offered, for });
-    }
+  // Returns true if an offer of type `Offered` exists at `offer_address`.
+  public fun exists_at<Offered>(offer_address: address): bool {
+    exists<T<Offered>>(offer_address)
+  }
 
-    // Claim the value of type `Offered` published at `offer_address`.
-    // Only succeeds if the sender is the intended recipient stored in `for` or the original
-    // publisher `offer_address`.
-    // Also fails if no such value exists.
-    public fun redeem<Offered>(offer_address: address): Offered acquires T {
-        let T<Offered> { offered, for } = move_from<T<Offered>>(offer_address);
-        let sender = Transaction::sender();
-        // fail with INSUFFICIENT_PRIVILEGES
-        Transaction::assert(sender == for || sender == offer_address, 11);
-        offered
-    }
-
-    // Returns true if an offer of type `Offered` exists at `offer_address`.
-    public fun exists_at<Offered>(offer_address: address): bool {
-        exists<T<Offered>>(offer_address)
-    }
-
-    // Returns the address of the `Offered` type stored at `offer_address.
-    // Fails if no such `Offer` exists.
-    public fun address_of<Offered>(offer_address: address): address acquires T {
-        borrow_global<T<Offered>>(offer_address).for
-    }
+  // Returns the address of the `Offered` type stored at `offer_address.
+  // Fails if no such `Offer` exists.
+  public fun address_of<Offered>(offer_address: address): address acquires T {
+    borrow_global<T<Offered>>(offer_address).for
+  }
 }
 }

--- a/lang/stdlib/signer.move
+++ b/lang/stdlib/signer.move
@@ -1,0 +1,21 @@
+address 0x0 {
+module Signer {
+    // Borrows the address of the signer
+    // Conceptually, you can think of the `signer` as being a resource struct wrapper arround an
+    // address
+    // ```
+    // resource struct Signer { addr: address }
+    // ```
+    // `borrow_address` borrows this inner field
+    native public fun borrow_address(s: &signer): &address;
+
+    // Copies the address of the signer
+    public fun address_of(s: &signer): address {
+        *borrow_address(s)
+    }
+
+    spec module {
+        native define get_address(account: signer): address;
+    }
+}
+}

--- a/lang/stdlib/transaction.move
+++ b/lang/stdlib/transaction.move
@@ -2,19 +2,12 @@ address 0x0 {
 
 module Transaction {
 
+    // Soon to be DEPRECATED!
     native public fun sender(): address;
 
     // inlined
     public fun assert(check: bool, code: u64) {
         if (check) () else abort code
     }
-
-    // Removed:
-    //
-    // native public fun sequence_number(): u64;
-    // native public fun public_key(): vector<u8>;
-    // native public fun gas_unit_price(): u64;
-    // native public fun max_gas_units(): u64;
-    // native public fun gas_remaining(): u64;
 }
 }


### PR DESCRIPTION
- Transaction::sender() is deprecated
- signer type is everywhere
- Account's native functions changed in favour of `move_to` + `signer` 