### PR TITLE
Migrate to clap v3 (DFI-261)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,10 +393,42 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
+dependencies = [
+ "heck",
+ "proc-macro-error 0.4.12",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
 ]
 
 [[package]]
@@ -716,6 +748,7 @@ name = "dvm-cli"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "clap 3.0.0-beta.1",
  "dvm-compiler",
  "dvm-data-source",
  "dvm-info",
@@ -732,7 +765,6 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-notify",
- "structopt",
  "tokio",
 ]
 
@@ -783,6 +815,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "clap 3.0.0-beta.1",
  "futures-util",
  "hyper",
  "log 0.4.8",
@@ -792,7 +825,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "structopt",
  "sys-info",
  "sysinfo",
  "tokio",
@@ -2174,7 +2206,7 @@ source = "git+https://github.com/dfinance/libra.git?branch=09.06.2020#cbec154498
 dependencies = [
  "anyhow",
  "bytecode-source-map",
- "clap",
+ "clap 2.33.1",
  "codespan 0.8.0",
  "codespan-reporting 0.8.0",
  "docgen",
@@ -2481,6 +2513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06de47b848347d8c4c94219ad8ecd35eb90231704b067e67e6ae2e36ee023510"
+
+[[package]]
 name = "palaver"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,14 +2699,40 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr 0.4.12",
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "proc-macro-error"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 1.0.2",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.31",
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2 1.0.18",
+ "quote 1.0.7",
+ "syn 1.0.31",
+ "syn-mid",
  "version_check 0.9.2",
 ]
 
@@ -2746,7 +2810,7 @@ version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a2bc4d0e40ac3216bd5618f2b985d5779994a463408596b5b7bf3e0824ff5e5"
 dependencies = [
- "clap",
+ "clap 2.33.1",
  "env_logger",
  "failure",
  "http",
@@ -3595,7 +3659,7 @@ source = "git+https://github.com/dfinance/libra.git?branch=09.06.2020#cbec154498
 dependencies = [
  "anyhow",
  "bytecode-verifier",
- "clap",
+ "clap 2.33.1",
  "datatest-stable",
  "include_dir",
  "libra-canonical-serialization",
@@ -3617,12 +3681,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "863246aaf5ddd0d6928dfeb1a9ca65f505599e4e1b399935ef7e75107516b4ef"
 dependencies = [
- "clap",
+ "clap 2.33.1",
  "lazy_static",
  "structopt-derive",
 ]
@@ -3634,7 +3704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
- "proc-macro-error",
+ "proc-macro-error 1.0.2",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.31",
@@ -3750,18 +3820,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ dvm-info = { path = "../info" }
 anyhow = "1.0"
 log = "0.4.8"
 env_logger = "0.7.1"
-structopt = "0.3"
+clap = "3.0.0-beta.1"
 http = "0.2"
 tokio = { version = "0.2", features = [ "macros", "rt-core", "rt-threaded", "blocking", "full", "time" ] }
 futures = "0.3"

--- a/cli/src/bin/dvm.rs
+++ b/cli/src/bin/dvm.rs
@@ -6,7 +6,7 @@
 extern crate log;
 
 use http::Uri;
-use structopt::StructOpt;
+use clap::Clap;
 
 use tonic::transport::Server;
 use futures::future::FutureExt;
@@ -35,41 +35,41 @@ const MODULE_CACHE: usize = 1000;
 ///  combined with Move compilation server
 ///  powered by gRPC interface on top of TCP/IPC.
 /// API described in protobuf schemas: https://github.com/dfinance/dvm-proto
-#[derive(Debug, StructOpt, Clone)]
-#[structopt(name = "dvm")]
-#[structopt(verbatim_doc_comment)]
+#[derive(Debug, Clone, Clap)]
+#[clap(name = "dvm")]
+#[clap(verbatim_doc_comment)]
 struct Options {
     /// Address in the form of HOST_ADDRESS:PORT.
     /// The address will be listen to by DVM and compilation server.
     /// Listening localhost by default.
     /// Supports schemes: http, ipc.
-    #[structopt(
+    #[clap(
         name = "listen address",
         default_value = "http://[::1]:50051",
         verbatim_doc_comment
     )]
     address: Endpoint,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     info_service: InfoServiceConfig,
 
     /// DataSource Server internet address.
-    #[structopt(
+    #[clap(
     name = "Data-Source URI",
     env = DVM_DATA_SOURCE,
     default_value = "http://[::1]:50052"
     )]
     ds: Uri,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     logging: LoggingOptions,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     integrations: IntegrationsOptions,
 }
 
 fn main() -> Result<()> {
-    let options = Options::from_args();
+    let options = Options::parse();
     let _guard = init(&options.logging, &options.integrations);
     main_internal(options)
 }

--- a/cli/src/bin/status-table.rs
+++ b/cli/src/bin/status-table.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 use libra::libra_types::vm_error::StatusCode;
-use structopt::StructOpt;
+use clap::Clap;
 use std::collections::HashMap;
 use enum_iterator::IntoEnumIterator;
 use anyhow::Result;
@@ -8,17 +8,17 @@ use std::fs::OpenOptions;
 use std::io::Write;
 
 /// Status table generator.
-#[derive(StructOpt)]
-#[structopt(name = "status-table")]
+#[derive(Clap)]
+#[clap(name = "status-table")]
 struct Opts {
     /// Optional path to the output file.
     /// If not passed, result will be printed to stdout.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     output: Option<PathBuf>,
 }
 
 fn main() {
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
     let status_table = status_table_json().unwrap();
     if let Some(output) = opts.output {
         let mut f = OpenOptions::new()

--- a/cli/src/bin/stdlib-builder.rs
+++ b/cli/src/bin/stdlib-builder.rs
@@ -1,33 +1,33 @@
 use std::{fs, io, path::PathBuf};
-use structopt::StructOpt;
+use clap::Clap;
 use serde_json::{to_string, to_string_pretty};
 use lang::stdlib::{build_external_std, Stdlib, WS};
 use std::path::Path;
 use anyhow::Error;
 use std::collections::HashMap;
 
-#[derive(StructOpt)]
-#[structopt(name = "stdlib-builder")]
+#[derive(Clap)]
+#[clap(name = "stdlib-builder")]
 struct Opts {
     /// Path to the directory with the standard library.
-    #[structopt()]
+    #[clap()]
     source_dir: String,
     /// Optional path to the output file.
     /// If not passed, result will be printed to stdout.
-    #[structopt(short, long, parse(from_os_str))]
+    #[clap(short, long, parse(from_os_str))]
     output: Option<PathBuf>,
 
-    #[structopt(short = "v", long = "verbose")]
+    #[clap(short = "v", long = "verbose")]
     /// Verbose mode flag.
     /// Enables debug printing of internals including used modules.
     debug_print: bool,
     /// Enables pretty printing of all output including debug-prints if it enabled.
-    #[structopt(short)]
+    #[clap(short)]
     pretty_print: bool,
 }
 
 fn main() {
-    let opts = Opts::from_args();
+    let opts = Opts::parse();
 
     let entries = fs::read_dir(&opts.source_dir)
         .unwrap()

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -14,9 +14,12 @@ pub const MAX_LOG_VERBOSE: u8 = 4;
 
 #[derive(Debug, Default, Clone, Clap)]
 pub struct LoggingOptions {
-    /// Enables maximum verbosity logging mode.
-    pub verbose: bool,
+    /// Enables verbosity logging mode.
+    /// Sets level of verbosity, and can be used multiple times.
+    /// Overrides or extends values paased as the `--log` parameter or `DVM_LOG` environment variable.
+    /// To set maximum level of verbosity use `-vvvv`.
     #[clap(short, long, parse(from_occurrences), verbatim_doc_comment)]
+    pub verbose: u8,
 
     /// Log filters.
     /// The same as standard RUST_LOG environment variable.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -16,7 +16,7 @@ pub const MAX_LOG_VERBOSE: u8 = 4;
 pub struct LoggingOptions {
     /// Enables verbosity logging mode.
     /// Sets level of verbosity, and can be used multiple times.
-    /// Overrides or extends values paased as the `--log` parameter or `DVM_LOG` environment variable.
+    /// Overrides or extends values passed as the `--log` parameter or `DVM_LOG` environment variable.
     /// To set maximum level of verbosity use `-vvvv`.
     #[clap(short, long, parse(from_occurrences), verbatim_doc_comment)]
     pub verbose: u8,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,4 +1,4 @@
-use structopt::StructOpt;
+use clap::Clap;
 
 // rust env variables
 pub const RUST_LOG: &str = "RUST_LOG";
@@ -10,17 +10,19 @@ pub const DVM_DATA_SOURCE: &str = "DVM_DATA_SOURCE";
 pub const DVM_SENTRY_DSN: &str = "DVM_SENTRY_DSN";
 pub const DVM_SENTRY_ENV: &str = "DVM_SENTRY_ENVIRONMENT";
 
-#[derive(Debug, Default, StructOpt, Clone)]
+pub const MAX_LOG_VERBOSE: u8 = 4;
+
+#[derive(Debug, Default, Clone, Clap)]
 pub struct LoggingOptions {
     /// Enables maximum verbosity logging mode.
-    #[structopt(long = "verbose", short = "v")]
     pub verbose: bool,
+    #[clap(short, long, parse(from_occurrences), verbatim_doc_comment)]
 
     /// Log filters.
     /// The same as standard RUST_LOG environment variable.
     /// Possible values in verbosity ordering: error, warn, info, debug and trace.
     /// For complex filters see documentation: https://docs.rs/env_logger/#filtering-results
-    #[structopt(
+    #[clap(
         long = "log",
         env = DVM_LOG,
         default_value = "info,dvm=info,hyper=warn,mio=warn",
@@ -31,7 +33,7 @@ pub struct LoggingOptions {
     /// Log colors and other styles.
     /// The same as standard RUST_LOG_STYLE environment variable.
     /// Possible values in verbosity ordering: auto, always, never.
-    #[structopt(
+    #[clap(
         long = "log-color",
         env = DVM_LOG_STYLE,
         default_value = "auto",
@@ -40,17 +42,17 @@ pub struct LoggingOptions {
     pub log_style: String,
 }
 
-#[derive(Debug, Default, StructOpt, Clone)]
+#[derive(Debug, Default, Clone, Clap)]
 pub struct IntegrationsOptions {
     /// Optional key-uri, enables crash logging service integration.
     /// If value ommited, crash logging service will not be initialized.
-    #[structopt(name = "Sentry DSN", long = "sentry-dsn", env = DVM_SENTRY_DSN)]
+    #[clap(name = "Sentry DSN", long = "sentry-dsn", env = DVM_SENTRY_DSN)]
     #[cfg(feature = "sentry")]
     pub sentry_dsn: Option<sentry::internals::Dsn>,
 
     /// Sets the environment code to separate events from testnet and production. Optional.
     /// Works with Sentry integration.
-    #[structopt(name = "Sentry environment", long = "sentry-env", env = DVM_SENTRY_ENV)]
+    #[clap(name = "Sentry environment", long = "sentry-env", env = DVM_SENTRY_ENV)]
     #[cfg(feature = "sentry")]
     pub sentry_env: Option<String>,
 }

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -9,6 +9,7 @@ pub(crate) mod support_sentry {
     use sentry::integrations::env_logger::init as sentry_log_init;
 
     /// Create standard logger, init integrations such as with sentry.
+    /// At the end init Libra's logger.
     pub fn init(
         log: &LoggingOptions,
         integrations: &IntegrationsOptions,
@@ -37,6 +38,11 @@ pub(crate) mod support_sentry {
         result
     }
 
+    /// Init integration with Sentry:
+    /// - integrate logger
+    /// - register panic handler.
+    ///
+    /// Returns guard for panic handler and api-client.
     pub fn init_sentry(dsn: &Dsn, env: &Option<String>) -> ClientInitGuard {
         // back-compat to default env var:
         std::env::set_var("SENTRY_DSN", format!("{}", &dsn));
@@ -85,6 +91,7 @@ mod support_libra_logger {
     }
 }
 
+/// Try init `env_logger` and then Libra's logger.
 pub fn init_logging(opts: &LoggingOptions) -> Result<(), log::SetLoggerError> {
     logging_builder(opts).try_init().and_then(|_| {
         support_libra_logger::init();
@@ -92,6 +99,8 @@ pub fn init_logging(opts: &LoggingOptions) -> Result<(), log::SetLoggerError> {
     })
 }
 
+/// Create and preconfigure `env_logger::Builder` using `LoggingOptions`
+/// typically previously produced by arguments passed to cli.
 pub fn logging_builder(opts: &LoggingOptions) -> env_logger::Builder {
     use env_logger::{Builder, Target};
 
@@ -106,31 +115,57 @@ pub fn logging_builder(opts: &LoggingOptions) -> env_logger::Builder {
     builder
 }
 
+/// Produces log-level for all packages
+/// including `dvm`,
+/// excluding some third-party dependencies.
+/// ```skip
+/// 0     => Info,
+/// 1     => Debug,
+/// 2 | _ => Trace,
+/// ```
 fn log_level(level: u8) -> log::Level {
     use log::Level::*;
     match level {
         0 => Info,
         1 => Debug,
-        2 | _ => Trace,
+        _ => Trace,
     }
 }
 
+/// Produces log-level for third-party dependencies.
+/// ```skip
+/// 0 | 1 | 2 => Info,
+/// 3         => Debug,
+/// 4 | _     => Trace,
+/// ```
 fn log_level_deps(level: u8) -> log::Level {
     use log::Level::*;
     match level {
         0 | 1 | 2 => Info,
         3 => Debug,
-        4 | _ => Trace,
+        _ => Trace,
     }
 }
+
+/// Produces log-filters-string in standard `RUST_LOG`-format.
+/// The log-level getting from `log_level_deps`.
+///
+/// List of filters contains crates:
+/// - mio
+/// - hyper
+/// - reqwest
+/// - tokio
+/// - tokio_util
+/// - h2
 fn log_filters_deps_format(level: u8) -> String {
-    // mio=info,hyper=info,reqwest=info,tokio=info,tokio_util=info,h2=info
     format!(
         "mio={0:},hyper={0:},reqwest={0:},tokio={0:},tokio_util={0:},h2={0:}",
         log_level_deps(level)
     )
 }
 
+/// Produces log-filters-string in standard `RUST_LOG`-format
+/// depending on the passed `LoggingOptions` including number of verbosity reqs, e.g. `-vvvv`
 fn log_filters_with_verbosity(opts: &LoggingOptions) -> String {
     match opts.verbose {
         0 => opts.log_filters.to_string(),
@@ -141,13 +176,9 @@ fn log_filters_with_verbosity(opts: &LoggingOptions) -> String {
             log_filters_deps_format(opts.verbose)
         ),
     }
-    // if opts.verbose {
-    //     format!("{},trace", opts.log_filters)
-    // } else {
-    //     opts.log_filters.to_string()
-    // }
 }
 
+/// Set env vars `RUST_LOG` & `RUST_LOG_STYLE` for backward compatibility.
 fn rust_log_compat(rust_log: &str, rust_log_style: &str) {
     use std::env::set_var;
     set_var(RUST_LOG, rust_log);
@@ -157,10 +188,10 @@ fn rust_log_compat(rust_log: &str, rust_log_style: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
-    use clap::Clap;
+    // use std::env;
+    // use clap::Clap;
 
-    const DSN: &str = "https://foobar@test.test/0000000";
+    // const DSN: &str = "https://foobar@test.test/0000000";
 
     #[test]
     fn parse_args_sentry() {
@@ -172,44 +203,67 @@ mod tests {
     }
 
     fn parse_args_sentry_off() {
-        // env::remove_var(DVM_SENTRY_DSN);
-        // let args = Vec::<String>::with_capacity(0).into_iter();
-        // let options = IntegrationsOptions::from_iter_safe(args);
-        // assert!(options.is_ok());
-        // assert!(options.unwrap().sentry_dsn.is_none());
+        env::remove_var(DVM_SENTRY_DSN);
+        let args = Vec::<String>::with_capacity(0).into_iter();
+        let options = IntegrationsOptions::from_iter_safe(args);
+        assert!(options.is_ok());
+        assert!(options.unwrap().sentry_dsn.is_none());
     }
 
     fn parse_args_sentry_on() {
-        // env::set_var(DVM_SENTRY_DSN, DSN);
-        // let args = Vec::<String>::with_capacity(0).into_iter();
-        // let options = IntegrationsOptions::from_iter_safe(args);
-        // assert!(options.is_ok());
+        env::set_var(DVM_SENTRY_DSN, DSN);
+        let args = Vec::<String>::with_capacity(0).into_iter();
+        let options = IntegrationsOptions::from_iter_safe(args);
+        assert!(options.is_ok());
 
-        // let options = options.unwrap();
-        // assert!(options.sentry_dsn.is_some());
-        // assert_eq!("foobar", options.sentry_dsn.unwrap().public_key());
+        let options = options.unwrap();
+        assert!(options.sentry_dsn.is_some());
+        assert_eq!("foobar", options.sentry_dsn.unwrap().public_key());
     }
 
     fn parse_args_sentry_override() {
-        // env::set_var(DVM_SENTRY_DSN, DSN);
-        // let args = ["", "--sentry-dsn", "https://0deedbeaf@test.test/0000000"].iter();
-        // let options = IntegrationsOptions::from_iter_safe(args);
-        // assert!(options.is_ok());
+        env::set_var(DVM_SENTRY_DSN, DSN);
+        let args = ["", "--sentry-dsn", "https://0deedbeaf@test.test/0000000"].iter();
+        let options = IntegrationsOptions::from_iter_safe(args);
+        assert!(options.is_ok());
 
-        // let options = options.unwrap();
-        // assert!(options.sentry_dsn.is_some());
-        // assert_eq!("0deedbeaf", options.sentry_dsn.unwrap().public_key());
+        let options = options.unwrap();
+        assert!(options.sentry_dsn.is_some());
+        assert_eq!("0deedbeaf", options.sentry_dsn.unwrap().public_key());
+    }
+
+    const DEF_LOG_FILTERS: &str = "default";
+
+    #[test]
+    fn log_filters_verbose_0() {
+        let log_filters = log_filters_verbose_v(0);
+        assert_eq!(DEF_LOG_FILTERS, &log_filters);
     }
 
     #[test]
-    fn log_filters_verbose() {
+    fn log_filters_verbose_1() {
+        let log_filters = log_filters_verbose_v(1);
+        assert!(log_filters.starts_with(&format!("{},{}", DEF_LOG_FILTERS, log::Level::Debug)));
+    }
+
+    #[test]
+    fn log_filters_verbose_2() {
+        let expected = format!("{},{}", DEF_LOG_FILTERS, log::Level::Trace);
+        assert!(log_filters_verbose_v(2).starts_with(&expected));
+        assert!(log_filters_verbose_v(3).starts_with(&expected));
+        assert!(log_filters_verbose_v(4).starts_with(&expected));
+    }
+
+
+    fn log_filters_verbose_v(v: u8) -> String {
         let opts = LoggingOptions {
-            verbose: MAX_LOG_VERBOSE,
+            verbose: v,
+            log_filters: DEF_LOG_FILTERS.to_owned(),
             ..Default::default()
         };
-        let log_filters = log_filters_with_verbosity(&opts);
-        assert_eq!(",trace", &log_filters);
+        log_filters_with_verbosity(&opts)
     }
+
 
     #[cfg(feature = "integrity-tests")]
     mod integrity {

--- a/cli/src/logging.rs
+++ b/cli/src/logging.rs
@@ -188,10 +188,10 @@ fn rust_log_compat(rust_log: &str, rust_log_style: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // use std::env;
-    // use clap::Clap;
+    use std::env;
+    use clap::Clap;
 
-    // const DSN: &str = "https://foobar@test.test/0000000";
+    const DSN: &str = "https://foobar@test.test/0000000";
 
     #[test]
     fn parse_args_sentry() {
@@ -205,7 +205,7 @@ mod tests {
     fn parse_args_sentry_off() {
         env::remove_var(DVM_SENTRY_DSN);
         let args = Vec::<String>::with_capacity(0).into_iter();
-        let options = IntegrationsOptions::from_iter_safe(args);
+        let options = IntegrationsOptions::try_parse_from(args);
         assert!(options.is_ok());
         assert!(options.unwrap().sentry_dsn.is_none());
     }
@@ -213,7 +213,7 @@ mod tests {
     fn parse_args_sentry_on() {
         env::set_var(DVM_SENTRY_DSN, DSN);
         let args = Vec::<String>::with_capacity(0).into_iter();
-        let options = IntegrationsOptions::from_iter_safe(args);
+        let options = IntegrationsOptions::try_parse_from(args);
         assert!(options.is_ok());
 
         let options = options.unwrap();
@@ -224,7 +224,7 @@ mod tests {
     fn parse_args_sentry_override() {
         env::set_var(DVM_SENTRY_DSN, DSN);
         let args = ["", "--sentry-dsn", "https://0deedbeaf@test.test/0000000"].iter();
-        let options = IntegrationsOptions::from_iter_safe(args);
+        let options = IntegrationsOptions::try_parse_from(args);
         assert!(options.is_ok());
 
         let options = options.unwrap();
@@ -254,7 +254,6 @@ mod tests {
         assert!(log_filters_verbose_v(4).starts_with(&expected));
     }
 
-
     fn log_filters_verbose_v(v: u8) -> String {
         let opts = LoggingOptions {
             verbose: v,
@@ -263,7 +262,6 @@ mod tests {
         };
         log_filters_with_verbosity(&opts)
     }
-
 
     #[cfg(feature = "integrity-tests")]
     mod integrity {

--- a/info/Cargo.toml
+++ b/info/Cargo.toml
@@ -23,5 +23,5 @@ futures-util = "0.3.5"
 bytes = "0.5.4"
 tokio = { version = "0.2", features = [ "macros", "rt-core", "rt-threaded", "blocking", "full" ] }
 prometheus_exporter_base = "0.30.4"
-structopt = "0.3"
+clap = "3.0.0-beta.1"
 sys-info = "0.7.0"

--- a/info/src/config.rs
+++ b/info/src/config.rs
@@ -1,11 +1,11 @@
 use std::net::SocketAddr;
-use structopt::StructOpt;
+use clap::Clap;
 
-#[derive(Debug, Default, StructOpt, Clone)]
+#[derive(Debug, Default, Clone, Clap)]
 pub struct InfoServiceConfig {
     /// Info service address  in the form of HOST_ADDRESS:PORT.
     /// Optional parameter. If the address is set, the web service starts.
-    #[structopt(
+    #[clap(
         name = "info service listen address. HOST_ADDRESS:PORT",
         long = "info-service-addr",
         short = "i",
@@ -14,8 +14,7 @@ pub struct InfoServiceConfig {
     pub info_service_addr: Option<SocketAddr>,
 
     /// Metric refresh interval in seconds.
-    #[structopt(
-        name = "Metric refresh interval in seconds.",
+    #[clap(
         default_value = "5",
         long = "metric-update-interval",
         verbatim_doc_comment
@@ -23,8 +22,7 @@ pub struct InfoServiceConfig {
     pub metric_update_interval: u64,
 
     /// Maximum period between heartbeats. In seconds.
-    #[structopt(
-        name = "Maximum period between heartbeats.",
+    #[clap(
         default_value = "5",
         long = "max-heartbeat-interval",
         verbatim_doc_comment
@@ -32,8 +30,7 @@ pub struct InfoServiceConfig {
     pub heartbeat_max_interval: u64,
 
     /// The interval between ping requests to dvm. In seconds.
-    #[structopt(
-        name = "The interval between ping requests to dvm. In seconds.",
+    #[clap(
         default_value = "4",
         long = "heartbeat_stimulation_interval",
         verbatim_doc_comment

--- a/info/src/config.rs
+++ b/info/src/config.rs
@@ -16,6 +16,7 @@ pub struct InfoServiceConfig {
     /// Metric refresh interval in seconds.
     #[clap(
         default_value = "5",
+        name = "seconds between updates",
         long = "metric-update-interval",
         verbatim_doc_comment
     )]
@@ -24,7 +25,8 @@ pub struct InfoServiceConfig {
     /// Maximum period between heartbeats. In seconds.
     #[clap(
         default_value = "5",
-        long = "max-heartbeat-interval",
+        name = "max seconds between heartbeats",
+        long = "heartbeat-interval-max",
         verbatim_doc_comment
     )]
     pub heartbeat_max_interval: u64,
@@ -32,7 +34,8 @@ pub struct InfoServiceConfig {
     /// The interval between ping requests to dvm. In seconds.
     #[clap(
         default_value = "4",
-        long = "heartbeat_stimulation_interval",
+        name = "seconds between heartbeats",
+        long = "heartbeat-pressure",
         verbatim_doc_comment
     )]
     pub heartbeat_stimulation_interval: u64,


### PR DESCRIPTION
Also there's various cli improvements:
- improved cli-params naming
- improved cli-params documentation
- improved cli verbosity level settings

__Breaking cli-api changes:__
- `max-heartbeat-interval` renamed to `heartbeat-interval-max`
- `heartbeat_stimulation_interval` to `heartbeat-pressure`

__Nonbreaking cli-api changes:__
- Previously `-v` changes log-level and so log-filters to `trace` for all. Now there is four levels of verbosity: from "-v not passed" to `-vvvv` as maximum level of verbosity (previously it was `-v`).